### PR TITLE
Add utility tests

### DIFF
--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -1,0 +1,16 @@
+import importlib
+
+
+def test_start_idempotent(monkeypatch):
+    calls = []
+
+    def fake_start(port):
+        calls.append(port)
+        if len(calls) > 1:
+            raise OSError("already started")
+
+    monkeypatch.setattr("scripts.metrics_server.start_http_server", fake_start)
+    ms = importlib.import_module("scripts.metrics_server")
+    ms.start(9999)
+    ms.start(9999)
+    assert calls == [9999, 9999]

--- a/tests/test_order_factory_contracts.py
+++ b/tests/test_order_factory_contracts.py
@@ -1,0 +1,52 @@
+from ibapi.order import Order
+
+from scripts.contracts import create_contract
+from scripts.order_factory import make_order
+
+
+def test_make_order_basic():
+    o = make_order("BUY", "LMT", 10, limit_px=123.45, account="ACC")
+    assert o.action == "BUY"
+    assert o.orderType == "LMT"
+    assert o.totalQuantity == 10
+    assert o.lmtPrice == 123.45
+    assert o.account == "ACC"
+    assert o.tif == "DAY"
+    assert o.eTradeOnly is False
+    assert o.firmQuoteOnly is False
+
+
+def test_make_order_defaults():
+    default_order = Order()
+    o = make_order("SELL", "MKT", 5)
+    assert o.lmtPrice == default_order.lmtPrice
+    assert o.account == ""
+    assert o.tif == "DAY"
+
+
+def test_create_contract_defaults():
+    c = create_contract("AAPL")
+    assert c.symbol == "AAPL"
+    assert c.secType == "STK"
+    assert c.exchange == "SMART"
+    assert c.currency == "USD"
+    assert c.primaryExchange == ""
+    assert c.tradingClass == ""
+    assert c.multiplier == ""
+
+
+def test_create_contract_with_options():
+    c = create_contract(
+        "ES",
+        secType="FUT",
+        exchange="GLOBEX",
+        currency="USD",
+        primaryExchange="CME",
+        lastTradeDateOrContractMonth="202406",
+        tradingClass="ES",
+        multiplier="50",
+    )
+    assert c.primaryExchange == "CME"
+    assert c.lastTradeDateOrContractMonth == "202406"
+    assert c.tradingClass == "ES"
+    assert c.multiplier == "50"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from utils.utils import Tick, setup_logger
+
+
+def test_tick_post_init():
+    t = Tick(
+        time=1_700_000_000, bid_price="1.2", ask_price="1.3", bid_size="5", ask_size="7"
+    )
+    assert t.timestamp_ == pd.to_datetime(1_700_000_000, unit="s")
+    assert isinstance(t.bid_price, float) and t.bid_price == 1.2
+    assert isinstance(t.ask_price, float) and t.ask_price == 1.3
+    assert t.bid_size == 5
+    assert t.ask_size == 7
+
+
+def test_setup_logger_creates_file(tmp_path):
+    log_file = tmp_path / "test.log"
+    logger = setup_logger("TestLogger", log_file=str(log_file))
+    logger.info("hello")
+    assert log_file.exists() and log_file.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add new tests for order_factory and contract helpers
- ensure metrics_server.start ignores repeat calls
- cover Tick dataclass and setup_logger helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b923ac948333bfcec6683c0052c5