### PR TITLE
Add Grafana dashboard

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,1 @@
+Import via Grafana → Dashboards → JSON.

--- a/grafana/TradingApp.json
+++ b/grafana/TradingApp.json
@@ -1,0 +1,89 @@
+{
+  "__schemaVersion": 38,
+  "uid": "trading-app",
+  "title": "Trading App",
+  "version": 1,
+  "refresh": "10s",
+  "tags": ["trading"],
+  "timezone": "browser",
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": { "refresh_intervals": ["5s","10s","30s","1m","5m"] },
+
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Ticks / sec",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "drawStyle": "lines", "lineWidth": 2 } },
+      "targets": [
+        {
+          "expr": "rate(ticks_total[1m])",
+          "legendFormat": "ticks/s",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "type": "timeseries",
+      "title": "Order Updates",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "drawStyle": "bars", "lineWidth": 1, "stacking": { "mode": "normal" } } },
+      "targets": [
+        {
+          "expr": "order_updates_total",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "type": "table",
+      "title": "Notional Exposure",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by(symbol)(positions_notional)",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "type": "timeseries",
+      "title": "PnL",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": { "defaults": { "drawStyle": "lines", "lineWidth": 2 } },
+      "targets": [
+        {
+          "expr": "pnl_total",
+          "legendFormat": "pnl",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "-- Grafana --", "uid": "-- grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0,211,255,1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+
+  "templating": { "list": [] },
+
+  "__requires": [
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "2.x" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "8.x" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "8.x" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `grafana/TradingApp.json` with basic panels
- note how to import the dashboard in `grafana/README.md`

## Testing
- `pip install -r requirements.txt`
- `pip install duckdb deepdiff`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6e0afb908333b1f34605370b5a1e