### PR TITLE
Add Helm chart for trading app

### DIFF
--- a/helm/charts/trading-app/Chart.yaml
+++ b/helm/charts/trading-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: trading-app
+description: Helm chart for trading app
+version: 0.1.0
+appVersion: "1.0"
+type: application

--- a/helm/charts/trading-app/README.md
+++ b/helm/charts/trading-app/README.md
@@ -1,0 +1,23 @@
+# trading-app Helm Chart
+
+This chart deploys the trading application along with a ConfigMap for environment variables and exposes metrics for Prometheus.
+
+## Installing
+
+```bash
+helm repo add myrepo https://example.com/helm-charts
+helm install trading-app myrepo/trading-app
+```
+
+## Values
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `env.IB_HOST` | IB Gateway host | `127.0.0.1` |
+| `env.IB_PORT` | IB Gateway port | `7497` |
+| `env.SYMBOLS` | Symbols list | `AAPL,MSFT,GOOG` |
+| `env.KILL_SWITCH` | Kill switch flag | `false` |
+| `service.metricsPort` | Metrics port | `9100` |
+| `hpa.targetValue` | HPA target ticks per second | `5` |
+
+After installation the service exposes metrics at `:9100/metrics` and the readiness probe hits `/ready` on port `8000`.

--- a/helm/charts/trading-app/templates/_helpers.tpl
+++ b/helm/charts/trading-app/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "trading-app.fullname" -}}
+{{ include "trading-app.name" . }}
+{{- end -}}
+
+{{- define "trading-app.name" -}}
+{{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "trading-app.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "trading-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "trading-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trading-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/charts/trading-app/templates/configmap.yaml
+++ b/helm/charts/trading-app/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trading-app.fullname" . }}-env
+  labels:
+    {{- include "trading-app.labels" . | nindent 4 }}
+data:
+  IB_HOST: {{ .Values.env.IB_HOST | quote }}
+  IB_PORT: {{ .Values.env.IB_PORT | quote }}
+  SYMBOLS: {{ .Values.env.SYMBOLS | quote }}
+  KILL_SWITCH: {{ .Values.env.KILL_SWITCH | quote }}

--- a/helm/charts/trading-app/templates/deployment.yaml
+++ b/helm/charts/trading-app/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trading-app.fullname" . }}
+  labels:
+    {{- include "trading-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "trading-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "trading-app.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "trading-app.fullname" . }}-env
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/helm/charts/trading-app/templates/hpa.yaml
+++ b/helm/charts/trading-app/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trading-app.fullname" . }}
+  labels:
+    {{- include "trading-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trading-app.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: "rate(ticks_total[1m])"
+        target:
+          type: Value
+          value: {{ .Values.hpa.targetValue | quote }}
+{{- end }}

--- a/helm/charts/trading-app/templates/service.yaml
+++ b/helm/charts/trading-app/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trading-app.fullname" . }}
+  labels:
+    {{- include "trading-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "trading-app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics

--- a/helm/charts/trading-app/values.yaml
+++ b/helm/charts/trading-app/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+
+image:
+  repository: trading-app
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8000
+  metricsPort: 9100
+
+env:
+  IB_HOST: "127.0.0.1"
+  IB_PORT: "7497"
+  SYMBOLS: "AAPL,MSFT,GOOG"
+  KILL_SWITCH: "false"
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetValue: "5"


### PR DESCRIPTION
## Summary
- add a new Helm chart under `helm/charts/trading-app`
- chart deploys the trading app with ConfigMap, Deployment, Service and HPA
- defaults for env vars in `values.yaml`
- documentation on installing the chart

## Testing
- `pip install -r requirements-dev.txt`
- `pip install duckdb deepdiff`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687db3b482108333ba64503c208a86de